### PR TITLE
Fix React version detection in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ export default [
                 sourceType: 'module',
             },
         },
-        settings: {react: {version: '18.3'}},
+        settings: {react: {version: 'detect'}},
         plugins: {
             react,
             'react-hooks': reactHooks,


### PR DESCRIPTION
## Summary
- correct React version detection in eslint.config.js

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684004c6c9a48327906b2f1e4688ae69