### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/scroll-to-top.jsx
+++ b/src/components/scroll-to-top.jsx
@@ -5,10 +5,10 @@ function ScrollToTop() {
     const { pathname } = useLocation();
 
     useEffect(() => {
+        if ("scrollRestoration" in window.history) {
+            window.history.scrollRestoration = "manual";
+        }
         window.scrollTo(0, 0);
-        document.querySelectorAll(".overflow-y-auto").forEach((el) => {
-            el.scrollTop = 0;
-        });
     }, [pathname]);
 
     return null;

--- a/src/pages/auth.jsx
+++ b/src/pages/auth.jsx
@@ -38,7 +38,7 @@ const tokenExchange = `curl -X POST https://idp.example.com/oauth2/token \\
 const Auth = () => {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto p-6 md:p-12 text-blue-900 bg-gradient-to-r from-blue-50 to-white rounded-xl shadow-lg text-center max-w-4xl mx-auto flex flex-col"
+            className="min-h-screen p-6 md:p-12 text-blue-900 bg-gradient-to-r from-blue-50 to-white rounded-xl shadow-lg text-center max-w-4xl mx-auto flex flex-col"
             variants={containerVariants}
             initial="hidden"
             animate="visible"

--- a/src/pages/cdc.jsx
+++ b/src/pages/cdc.jsx
@@ -60,7 +60,7 @@ const technologies = [
 const CDC = () => {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto p-6 md:p-12 text-blue-900 bg-gradient-to-r from-blue-50 to-white rounded-xl shadow-lg text-center max-w-4xl mx-auto flex flex-col"
+            className="min-h-screen p-6 md:p-12 text-blue-900 bg-gradient-to-r from-blue-50 to-white rounded-xl shadow-lg text-center max-w-4xl mx-auto flex flex-col"
             variants={containerVariants}
             initial="hidden"
             animate="visible"

--- a/src/pages/certification.jsx
+++ b/src/pages/certification.jsx
@@ -62,7 +62,7 @@ const itemVariants = {
 function Certification() {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto
+            className="min-h-screen
                  p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col"

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -36,7 +36,7 @@ const itemVariants = {
 function Contact() {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto
+            className="min-h-screen
                  p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col"

--- a/src/pages/data-platform.jsx
+++ b/src/pages/data-platform.jsx
@@ -53,7 +53,7 @@ const benefits = [
 const DataPlatform = () => {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto
+            className="min-h-screen
                  p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg text-center

--- a/src/pages/database-versioning.jsx
+++ b/src/pages/database-versioning.jsx
@@ -62,7 +62,7 @@ const benefits = [
 const DatabaseVersioning = () => {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto
+            className="min-h-screen
                  p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg text-center

--- a/src/pages/event-driven-architecture.jsx
+++ b/src/pages/event-driven-architecture.jsx
@@ -66,7 +66,7 @@ const benefits = [
 const EventDrivenArchitecture = () => {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto
+            className="min-h-screen
                  p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg text-center

--- a/src/pages/experience.jsx
+++ b/src/pages/experience.jsx
@@ -55,7 +55,7 @@ const itemVariants = {
 function Experience() {
     return (
         <motion.section
-            className="h-[100dvh] md:h-auto overflow-y-auto
+            className="min-h-screen
                  p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col"

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -37,7 +37,7 @@ export const animations = {
 // Common class combinations
 export const classes = {
   pageContainer: `
-    h-[100dvh] md:h-auto overflow-y-auto
+    min-h-screen
     p-6 md:p-12 text-blue-900
     bg-gradient-to-r from-blue-50 to-white
     rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col


### PR DESCRIPTION
## Summary
- use `min-h-screen` container height to allow normal page scrolling
- apply new container class across all pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c395eb17883279dadc25e6d7c82ff