### PR TITLE
Trim extra height from content pages

### DIFF
--- a/src/pages/certification.jsx
+++ b/src/pages/certification.jsx
@@ -62,8 +62,7 @@ const itemVariants = {
 function Certification() {
     return (
         <motion.section
-            className="min-h-screen
-                 p-6 md:p-12 text-blue-900
+            className="p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col"
             variants={containerVariants}

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -36,8 +36,7 @@ const itemVariants = {
 function Contact() {
     return (
         <motion.section
-            className="min-h-screen
-                 p-6 md:p-12 text-blue-900
+            className="p-6 md:p-12 text-blue-900
                  bg-gradient-to-r from-blue-50 to-white
                  rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col"
             variants={containerVariants}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -37,7 +37,6 @@ export const animations = {
 // Common class combinations
 export const classes = {
   pageContainer: `
-    min-h-screen
     p-6 md:p-12 text-blue-900
     bg-gradient-to-r from-blue-50 to-white
     rounded-xl shadow-lg max-w-4xl mx-auto flex flex-col


### PR DESCRIPTION
## Summary
- reduce vertical spacing for standard page layout
- adjust Certification and Contact sections to fit content

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c431c96948327bf4dc8a7dc88e4f3