### PR TITLE
Add GitHub project link to CDC page

### DIFF
--- a/src/pages/cdc.jsx
+++ b/src/pages/cdc.jsx
@@ -155,6 +155,16 @@ const CDC = () => {
                     </p>
                 </div>
             </div>
+            <div className="mt-8 text-center">
+                <a
+                    href="https://github.com/stefanoauciello/e-commerce-cdc"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-secondary"
+                >
+                    Check My Project on GitHub
+                </a>
+            </div>
         </motion.section>
     );
 };


### PR DESCRIPTION
## Summary
- add "Check My Project on GitHub" button to the CDC page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: several lint errors in unrelated files)*
- `npx eslint src/pages/cdc.jsx`

------
https://chatgpt.com/codex/tasks/task_e_688d2a51c400832797fe6e5fcc57680d